### PR TITLE
Extending block-rule feature set

### DIFF
--- a/src/domain.ts
+++ b/src/domain.ts
@@ -14,12 +14,21 @@ export enum RuleScope {
     INLINE
 }
 
-export type Rule = {
+export type Renderer = {
     name: string;
+    react(node: ASTNode, ast: AST): ReactElementDescription;
+}
+export type RendererMap = {
+    [name: string]: Renderer
+}
+
+export type Rule = Renderer & {
     scope: RuleScope;
     regex: RegExp;
     parse(match: RegexMatch): ASTNode;
-    react(node: ASTNode, ast: AST): ReactElementDescription;
+    extraRenderers?: {
+        [key: string]: Renderer['react']
+    };
     [key: string]: any;
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,7 +22,7 @@ export function minBy<T>(fn: (t: T) => number) {
         const accFn = fn(acc);
         const valueFn = fn(value);
 
-        return accFn < valueFn ? acc : value;
+        return accFn <= valueFn ? acc : value;
     };
 }
 

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -24,6 +24,11 @@ Best regards
 Your name
 Your office
 `.trim();
+const example2 = `
+This is the first paragraph
+
+This is the second paragraph
+`.trim()
 
 const rules: Array<Rule> = [HighlightRule, BoldRule, LinkRule, LinebreakRule, ParagraphRule];
 const whitespace = /\s/g;
@@ -59,6 +64,29 @@ describe('textparser - parse', () => {
     it('should handle empty ruleset', () => {
         const ast = parse(example, []);
         expect(ast).toMatchObject([example]);
+    });
+
+    it('should not recurse block-rules', () => {
+        const customParagraphRule: Rule = {
+            ...ParagraphRule,
+            name: 'custom-paragraph',
+            react(node: string | { name: string; content: AST }): ReactElementDescription {
+                return {type: 'p', props: {className: 'paragraph-class'}}
+            }
+        };
+
+        const customRules = [ParagraphRule, customParagraphRule];
+        const ast = parse(example2, customRules);
+        expect(ast).toMatchObject([
+            {
+                name: 'Paragraph',
+                content: ['This is the first paragraph']
+            },
+            {
+                name: 'Paragraph',
+                content: ['This is the second paragraph']
+            }
+        ]);
     });
 });
 


### PR DESCRIPTION
* fix: 🐛 prioritize first matching rule d4d261e
if two rules both started their match on the same index, then we want to
prioritize based on the order of the rules.

* fix: 🐛 recursion of block-rules 8034db9
block-rules should be digest content in a single pass, and not fall into
recursive parsing which may result in nested paragraph ( or other
block-types)

* feat: 🎸 allow definition of sub-renderers within rule 90375da
some block-rules may need sub-renderers in order to be implemented in a
consise manner, ex. ul->li. This change, and the splitting of renderers
from the rule-definitions is to support these kinds of rules