### PR TITLE
ci: 🎡 add dual-publishing to gpr

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -19,6 +19,9 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
       - name: Install dependencies
         run: npm ci
       - name: Test

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,6 +19,9 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
       - name: Install dependencies
         run: npm ci
       - name: Test

--- a/.github/workflows/publish-ghpr.yaml
+++ b/.github/workflows/publish-ghpr.yaml
@@ -1,0 +1,44 @@
+name: Publish package to GPR
+
+on:
+  release:
+    types:
+      - published
+      - edited
+
+# GITHUB_SHA: last commit in tagget release
+# GITHUB_REF: tag of release
+
+env:
+  CI: true
+jobs:
+  test-build-publish:
+    name: Test and build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          ref: ${{ GITHUB_REF }}
+      - uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-14-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - uses: actions/setup-node@v2
+        with:
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@navikt'
+          node-version: 14
+      - name: Set version
+        run: npm version ${{ GITHUB_REF }} --allow-same-version --git-tag-version=false
+      - name: Install dependencies
+        run: npm ci
+      - name: Test
+        run: npm run test:coverage
+      - name: Build
+        run: npm run build
+      - name: Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-ghpr.yaml
+++ b/.github/workflows/publish-ghpr.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/cache@v1
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-14-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
       - uses: actions/setup-node@v2


### PR DESCRIPTION
Since the organization use the scope "@navikt" on github and npmjs it is
necessary to dual-publish in order for consumers to utilize private
packages from GPR.
